### PR TITLE
Add compatibility with plugin Min Max Step Quantity Limits Manager for WooCommerce

### DIFF
--- a/inc/compat/plugins/compat-plugin-product-quantity-for-woocommerce.php
+++ b/inc/compat/plugins/compat-plugin-product-quantity-for-woocommerce.php
@@ -1,0 +1,123 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Compatibility with plugin: Min Max Step Quantity Limits Manager for WooCommerce (by WPFactory).
+ */
+class FluidCheckout_ProductQuantityForWooCommerce extends FluidCheckout {
+
+	/**
+	 * __construct function.
+	 */
+	public function __construct() {
+		$this->hooks();
+	}
+
+
+
+	/**
+	 * Initialize hooks.
+	 */
+	public function hooks() {
+		// Late hooks
+		add_action( 'init', array( $this, 'late_hooks' ), 100 );
+	}
+
+	/**
+	 * Add or remove late hooks.
+	 */
+	public function late_hooks() {
+		// Checkout page hooks
+		$this->checkout_hooks();
+	}
+
+	/**
+	* Add or remove checkout page hooks.
+	*/
+	public function checkout_hooks() {
+		// Bail if not on checkout page
+		if ( ! FluidCheckout_Steps::instance()->is_checkout_page_or_fragment() ) { return; }
+
+		// Bail if required class is not available
+		$class_name = 'Alg_WC_PQ_Core';
+		if ( ! class_exists( $class_name ) ) { return; }
+
+		// Get class object
+		$class_object = FluidCheckout::instance()->get_object_by_class_name_from_hooks( $class_name );
+
+		// Quantity input args
+		remove_filter( 'woocommerce_quantity_input_args', array( $class_object, 'set_quantity_input_args' ), PHP_INT_MAX - 100, 2 ); // Use the same priority as in the plugin
+		add_filter( 'woocommerce_quantity_input_args', array( $this, 'set_quantity_input_args' ), PHP_INT_MAX - 100, 2 ); // Use the same priority as in the plugin
+	}
+
+
+
+	/**
+	 * Set quantity input args.
+	 * COPIED AND ADAPTED FROM: Alg_WC_PQ_Core::set_quantity_input_args().
+	 *
+	 * @param  array       $args     Quantity input arguments.
+	 * @param  WC_Product  $product  Product object.
+	 */
+	public function set_quantity_input_args( $args, $product ) {
+		global $wp_query;
+
+		// Bail if required class is not available
+		$class_name = 'Alg_WC_PQ_Core';
+		if ( ! class_exists( $class_name ) ) { return; }
+
+		// Get class object
+		$class_object = FluidCheckout::instance()->get_object_by_class_name_from_hooks( $class_name );
+
+		$category_name = '';
+		if ( isset( $wp_query->query_vars[ 'product_cat' ] ) ) {
+			$category_name = $wp_query->query_vars[ 'product_cat' ];
+		}
+
+		if ( empty( $product ) ) {
+			return $args;
+		}
+
+		if ( 'yes' === get_option( 'alg_wc_pq_min_section_enabled', 'no' ) ) {
+			$args[ 'min_value' ] = $class_object->set_quantity_input_min( $args[ 'min_value' ], $product );
+
+			// CHANGE: Remove `is_cart()` check as it's no longer needed
+			if ( $product->managing_stock() && $product->get_stock_quantity() === $args[ 'min_value' ] ) {
+				$args[ 'min_value' ] = 0;
+				$args[ 'readonly' ]  = true;
+			}
+		} 
+		elseif ( 'yes' === get_option( 'alg_wc_pq_force_cart_min_enabled', 'no' ) ) {
+			$args[ 'min_value' ] = 1;
+		}
+		if ( 'yes' === get_option( 'alg_wc_pq_max_section_enabled', 'no' ) ) {
+			$args[ 'max_value' ] = $class_object->set_quantity_input_max( $args[ 'max_value' ], $product );
+		}
+		if ( 'yes' === get_option( 'alg_wc_pq_step_section_enabled', 'no' ) ) {
+			$args[ 'step' ] = $class_object->set_quantity_input_step( $args[ 'step' ], $product );
+		}
+
+		// CHANGE: Remove the part for setting the "Fixed quantity" for product archives and single product pages
+		// CHANGE: Remove the part for product archives with false positive conditions on pages where fragment updates are used
+		// CHANGE: Remove the part for non-WooCommerce pages
+		// CHANGE: Remove the part for single product pages
+		// CHANGE: Remove the part for product archives
+
+		$args[ 'product_id' ] = ( $product ? $product->get_id() : 0 );
+
+		if ( isset( $_SERVER[ 'REQUEST_METHOD' ] ) && $_SERVER[ 'REQUEST_METHOD' ] != 'POST' ) {
+			if ( isset( $args[ 'input_value' ] ) && empty( $args[ 'input_value' ] ) ) {
+				$args[ 'input_value' ] = 1;
+			}
+		}
+
+		if ( isset( $args[ 'step' ] ) && empty( $args[ 'step' ] ) ) {
+			$args[ 'step' ] = 1;
+		}
+
+		return $args;
+	}
+
+}
+
+FluidCheckout_ProductQuantityForWooCommerce::instance();

--- a/readme.txt
+++ b/readme.txt
@@ -358,6 +358,7 @@ The plugin provides widget areas in strategic positions on the checkout page for
 
 * Added: Compatibility with plugin Advanced Flat Rate Shipping For WooCommerce Premium.
 * Added: Compatibility with plugin Flat Rate Shipping Method for WooCommerce.
+* Added: Compatibility with plugin Min Max Step Quantity Limits Manager for WooCommerce.
 * Fixed: Progress bar showing only steps title when invalid values are defined for the option. Should revert to default "Bars" style.
 
 = 4.1.1 - 2025-08-22 =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added compatibility with the “Min Max Step Quantity Limits Manager for WooCommerce,” ensuring quantity fields at checkout respect minimum, maximum, and step rules, including stock-aware behavior and sensible defaults.
  * Improved handling of quantity input values during non-POST requests and ensured consistent product ID mapping for checkout quantity fields.
* Documentation
  * Updated changelog to note the new compatibility with the Min Max Step Quantity Limits Manager for WooCommerce.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->